### PR TITLE
Hide "dead" trainer Pokémon by default, add option to show all (#366)

### DIFF
--- a/core/js/trainer.content.js
+++ b/core/js/trainer.content.js
@@ -152,30 +152,33 @@ function printTrainer(trainer, trainerIndex, pokeimg_suffix, iv_numbers, locale)
 	trainersInfos.append($('<td>', { id: 'trainerLevel_' + trainer.name, text: trainer.level }));
 	trainersInfos.append($('<td>', { id: 'trainerGyms_' + trainer.name, text: trainer.gyms }));
 	trainersInfos.append($('<td>', { id: 'trainerLastSeen_' + trainer.name, text: trainer.last_seen }));
+	trainersInfos.append($('<td>', { id: 'trainerShowAll_' + trainer.name }).append('<input type="checkbox" id="showAll">'));
 	$('#trainersContainer').append(trainersInfos);
 	var trainersPokemonsRow = $('<tr>', { id: 'trainerPokemons_' + trainer.name });
-	var trainersPokemons = $('<td>', { colspan: 6 });
+	var trainersPokemons = $('<td>', { colspan: 7 });
 	var trainersPokemonsContainer = $('<div>', { class: '' });
 	for (var pokeIndex = 0; pokeIndex < trainer.pokemons.length; pokeIndex++) {
 		var pokemon = trainer.pokemons[pokeIndex];
 		trainersPokemonsContainer.append(printPokemon(pokemon, pokeimg_suffix, iv_numbers, locale));
 	}
-
+	trainersInfos.find('#showAll').click(function() {
+		trainersPokemonsContainer.find('div.pokemon-single.unseen').fadeToggle();
+	});
 	trainersPokemons.append(trainersPokemonsContainer);
 	trainersPokemonsRow.append(trainersPokemons);
 	$('#trainersContainer').append(trainersPokemonsRow);
 }
 
 function printPokemon(pokemon, pokeimg_suffix, iv_numbers, locale) {
-	var trainerPokemon = $('<div>', { id: 'trainerPokemon_' + pokemon.pokemon_uid, class: 'col-md-1 col-xs-4 pokemon-single', style: 'text-align: center' });
-	var gymClass = '';
-	if (pokemon.gym_id === null) {
-		gymClass = 'unseen';
+	var gymClass = pokemon.gym_id === null ? ' unseen' : '';
+	var trainerPokemon = $('<div>', { id: 'trainerPokemon_' + pokemon.pokemon_uid, class: 'col-md-1 col-xs-4 pokemon-single' + gymClass, style: 'text-align: center' });
+	if (gymClass) {
+		trainerPokemon.hide();
 	}
 	trainerPokemon.append(
 		$('<a>', { href: 'pokemon/' + pokemon.pokemon_id }).append($('<img />', {
 			src: 'core/pokemons/' + pokemon.pokemon_id + pokeimg_suffix,
-			'class': 'img-responsive ' + gymClass
+			'class': 'img-responsive' + gymClass
 		}))
 	);
 	trainerPokemon.append($('<p>', { class: 'pkmn-name' }).append(pokemon.cp));

--- a/core/json/locales/DE/translations.json
+++ b/core/json/locales/DE/translations.json
@@ -153,6 +153,7 @@
 "TRAINERS_TABLE_LEVEL" : "Level",
 "TRAINERS_TABLE_NAME" : "Name",
 "TRAINERS_TABLE_SAME_LEVEL" : "Gleiches Level",
+"TRAINERS_TABLE_SHOW_ALL" : "Zeige alle",
 "TRAINERS_TITLE": "Finde den wahren <strong>Pokémon-Meister</strong><br><small>Trainer und deren Pokémon in Arenen</small>",
 "UNSEEN": "nicht gesehen",
 "VALOR": "Wagemut",

--- a/core/json/locales/EN/translations.json
+++ b/core/json/locales/EN/translations.json
@@ -154,6 +154,7 @@
 "TRAINERS_TABLE_LEVEL" : "Level",
 "TRAINERS_TABLE_NAME" : "Name",
 "TRAINERS_TABLE_SAME_LEVEL" : "Same Level",
+"TRAINERS_TABLE_SHOW_ALL" : "Show All",
 "TRAINERS_TITLE": "Find the real <strong>Pokémon Master</strong><br><small>Trainers and their Pokémon in gyms</small>",
 "UNSEEN": "unseen",
 "VALOR": "Valor",

--- a/pages/trainer.page.php
+++ b/pages/trainer.page.php
@@ -82,6 +82,7 @@
 					<th><?= $locales->TRAINERS_TABLE_LEVEL ?></th>
 					<th><?= $locales->TRAINERS_TABLE_GYMS ?></th>
 					<th><?= $locales->TRAINERS_TABLE_LAST_SEEN ?></th>
+					<th><?= $locales->TRAINERS_TABLE_SHOW_ALL ?></th>
 				</tr>
 				</thead>
 				<tbody id="trainersContainer">
@@ -89,10 +90,10 @@
 				</tbody>
 				<tfoot>
 					<tr class="loadMore text-center">
-						<td colspan="6"><button id="loadMoreButton" class="btn btn-default hidden"><?= $locales->TRAINERS_LOAD_MORE ?></button></td>
+						<td colspan="7"><button id="loadMoreButton" class="btn btn-default hidden"><?= $locales->TRAINERS_LOAD_MORE ?></button></td>
 					</tr>
 					<tr class="trainerLoader">
-						<td colspan="6"><div class="loader"></div></td>
+						<td colspan="7"><div class="loader"></div></td>
 					</tr>
 				</tfoot>
 			</table>


### PR DESCRIPTION
* Hide dead trainer pokemon by default, add option to show all

* Add DE/EN translations

* Fix scrutinizer issue

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
